### PR TITLE
hide hamburger from medium breakpoint and up

### DIFF
--- a/_sass/_sliding-menu.scss
+++ b/_sass/_sliding-menu.scss
@@ -50,6 +50,9 @@
       transform: translateX(em(-900)); /* reset slide position */
     }
   }
+  @include media($medium) {
+    display: none;
+  }
 }
 
 /*


### PR DESCRIPTION
Hides the skinny-bones-inherited redundant hamburger menu on `$medium` and up viewports.